### PR TITLE
Fixed text-labelling issue Planned Charge when Friendly-text set True

### DIFF
--- a/predbat-table-card.js
+++ b/predbat-table-card.js
@@ -402,8 +402,7 @@ class PredbatTableCard extends HTMLElement {
                     friendlyText = friendlyText.replace('FreezeDis', 'Charging Paused');
                     friendlyText = friendlyText.replace('FreezeChrg', 'Maintaining SOC'); //FreezeChrg
                     friendlyText = friendlyText.replace('HoldChrg', 'Maintaining SOC'); //HoldChrg
-                    friendlyText = friendlyText.replace('NoCharge', 'Charge to "Limit"'); //NoCharge                   
-                    friendlyText = friendlyText.replace('Charge', 'Planned Charge'); //Charge 
+                    friendlyText = friendlyText.includes("NoCharge") ? friendlyText.replace('NoCharge','Charge to "limit"') : friendlyText.replace('Charge', 'Planned Charge');
                     friendlyText = friendlyText.replace('Discharge', 'Planned Discharge'); //Discharge
                    
                     if(this.config.use_friendly_states === true){


### PR DESCRIPTION
Love the card - spotted something that might be intended behaviour, but that felt off... so here's a PR for a fix

Previous behaviour:

when friendlyText = "NoCharge":

line 405 replaces this with 'Charge to "Limit"' and then line 406 replaces the word "Charge" with "Planned Charge"

Resulting in friendlyText = Planned Charge to "Limit"  - which seemed not the desired result